### PR TITLE
Add CDTS WxT templates for GCWeb theming

### DIFF
--- a/src/Web/WebSPA/public/helper/startswith.js
+++ b/src/Web/WebSPA/public/helper/startswith.js
@@ -1,0 +1,55 @@
+/*! https://mths.be/startswith v0.2.0 by @mathias */
+if (!String.prototype.startsWith) {
+	(function() {
+		'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
+		var defineProperty = (function() {
+			// IE 8 only supports `Object.defineProperty` on DOM elements
+			try {
+				var object = {};
+				var $defineProperty = Object.defineProperty;
+				var result = $defineProperty(object, object, object) && $defineProperty;
+			} catch(error) {}
+			return result;
+		}());
+		var toString = {}.toString;
+		var startsWith = function(search) {
+			if (this == null) {
+				throw TypeError();
+			}
+			var string = String(this);
+			if (search && toString.call(search) == '[object RegExp]') {
+				throw TypeError();
+			}
+			var stringLength = string.length;
+			var searchString = String(search);
+			var searchLength = searchString.length;
+			var position = arguments.length > 1 ? arguments[1] : undefined;
+			// `ToInteger`
+			var pos = position ? Number(position) : 0;
+			if (pos != pos) { // better `isNaN`
+				pos = 0;
+			}
+			var start = Math.min(Math.max(pos, 0), stringLength);
+			// Avoid the `indexOf` call if no match is possible
+			if (searchLength + start > stringLength) {
+				return false;
+			}
+			var index = -1;
+			while (++index < searchLength) {
+				if (string.charCodeAt(start + index) != searchString.charCodeAt(index)) {
+					return false;
+				}
+			}
+			return true;
+		};
+		if (defineProperty) {
+			defineProperty(String.prototype, 'startsWith', {
+				'value': startsWith,
+				'configurable': true,
+				'writable': true
+			});
+		} else {
+			String.prototype.startsWith = startsWith;
+		}
+	}());
+}

--- a/src/Web/WebSPA/public/helper/wet.js
+++ b/src/Web/WebSPA/public/helper/wet.js
@@ -1,0 +1,39 @@
+window.onload = function() {
+    reloadTemplate();
+  };
+  
+  function reloadTemplate(){
+    var language = document.getElementsByTagName("html")[0].getAttribute('lang');
+    var switchLanguage = language.startsWith('en') ? 'fr' : 'en';
+  
+    var defTop = document.getElementById("def-top");
+    defTop.outerHTML = wet.builder.appTop({
+      appName: [
+        {
+          href: "#",
+          text: (switchLanguage === 'en' ? "[FR] Title" : 'Hello ESDC')
+        }
+      ],
+      search: false,
+      lngLinks: [
+        {
+          lang: switchLanguage,
+          href: "?lang=" + switchLanguage,
+          text: (switchLanguage === 'en' ? 'English' : 'Français')
+        }
+      ],
+      showPreContent: false,
+      topSecMenu: false
+    });
+  
+    var defPreFooter = document.getElementById("def-preFooter");
+    defPreFooter.outerHTML = wet.builder.preFooter({
+      dateModified: "2019-03-29",
+      versionIdentifier: "0.0.4",
+      showPostContent: false
+    });
+  
+    var defFooter = document.getElementById("def-footer");
+    defFooter.outerHTML = wet.builder.appFooter({
+    });
+  }

--- a/src/Web/WebSPA/public/index.html
+++ b/src/Web/WebSPA/public/index.html
@@ -6,12 +6,34 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>spa-vue</title>
+    <script src="helper/startswith.js" type="text/javascript"></script>
+    <!--  CDTS implementation -->
+    <script type="text/javascript" src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/soyutils.js"></script>
+    <script type="text/javascript" src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_30/cdts/compiled/wet-en.js"></script>
+
+    <script type="text/javascript">
+      document.write(wet.builder.refTop({
+        cdnEnv: 'prod',
+        subTheme: 'gcweb',
+        jqueryEnv: 'external',
+        localPath: '',
+        isApplication: true
+      }));
+    </script>
+
+    <script type="text/javascript" src="helper/wet.js"></script>
   </head>
   <body>
+    <div id="def-top"></div>
     <noscript>
       <strong>We're sorry but spa-vue doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
-    <div id="app"></div>
-    <!-- built files will be auto injected -->
+    <main id="wb-cont" role="main" property="mainContentOfPage" class="container">
+      <div id="app"></div>
+      <!-- built files will be auto injected -->
+
+      <div id="def-preFooter"></div>
+    </main>
+    <div id="def-footer"></div>
   </body>
 </html>

--- a/src/Web/WebSPA/src/App.vue
+++ b/src/Web/WebSPA/src/App.vue
@@ -16,13 +16,4 @@ export default {
 };
 </script>
 
-<style lang="scss">
-#app {
-  font-family: "Avenir", Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  margin-top: 60px;
-}
-</style>
+<style lang="scss"></style>


### PR DESCRIPTION
@CalvinRodo Thanks for the recommendation... that was surprisingly painless. I just copied over implementation from one of the repos you posted on the previous PR.

Any insight on those `startswith.js` and `wet.js` files that had to be included? Maybe something we can refactor into a cleaner implementation? I've only briefly scanned them, but thought I'd check with you first.